### PR TITLE
Fix - Mapbox GL JS Dependency Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "control"
   ],
   "dependencies": {
-    "mapbox-gl": "^0.29.0"
+    "mapbox-gl": "^0.26.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ First you will need to get the Mapbox GL JS library installed to your project vi
 
 ```
 $ cd /your/framer/project
-$ npm i mapbox-gl
+$ npm i mapbox-gl@0.26.0
 ```
 
 Next, copy / save the `MapboxLayer.coffee` file into your project's `modules` folder.


### PR DESCRIPTION
## Description of Pull Request
Explicitly install older version of mapbox to eliminate Framer issue
